### PR TITLE
ci: set timeout in golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,3 +19,5 @@ jobs:
         uses: golangci/golangci-lint-action@v2.5.1
         with:
           version: v1.29
+          args: --timeout 5m
+          skip-go-installation: true


### PR DESCRIPTION
Increased from 1m to 5m. Also skip go setup in the linter action.

Signed-off-by: roee88 <roee88@gmail.com>