### PR TITLE
feat: Include schema in model

### DIFF
--- a/example/crds/example.yaml
+++ b/example/crds/example.yaml
@@ -23,12 +23,18 @@ spec:
               additionalProperties:
                 properties:
                   code:
+                    description: Some code
                     type: integer
+                    format: int32
+                    default: 7
+                    minimum: 0
+                    maximum: 10
                   text:
+                    description: Just text
                     type: string
                   area:
                     type: string
-                    description: Area...
+                    description: Some area
                     enum:
                       - East
                       - West

--- a/example/output.md
+++ b/example/output.md
@@ -52,7 +52,9 @@ Resource Types:
       </tr><tr>
         <td><b><a href="#examplemessagesindexkey">messages</a></b></td>
         <td>[]map[string]object</td>
-        <td></td>
+        <td>
+          <br/>
+        </td>
         <td>false</td>
       </tr></tbody>
 </table>
@@ -77,17 +79,30 @@ Resource Types:
     <tbody><tr>
         <td><b>area</b></td>
         <td>enum</td>
-        <td>Area... [East West]</td>
+        <td>
+          Some area<br/>
+          <br/>
+            <i>Enum</i>: East, West<br/>
+        </td>
         <td>false</td>
       </tr><tr>
         <td><b>code</b></td>
         <td>integer</td>
-        <td></td>
+        <td>
+          Some code<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Default</i>: 7<br/>
+            <i>Minimum</i>: 0<br/>
+            <i>Maximum</i>: 10<br/>
+        </td>
         <td>false</td>
       </tr><tr>
         <td><b>text</b></td>
         <td>string</td>
-        <td></td>
+        <td>
+          Just text<br/>
+        </td>
         <td>false</td>
       </tr></tbody>
 </table>

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -161,9 +161,6 @@ func (b *ModelBuilder) addTypeModels(groupModel *GroupModel, kindModel *KindMode
 			}
 
 			fieldDescription := property.Description
-			if fieldTypename == "enum" {
-				fieldDescription = fmt.Sprintf("%s %s", fieldDescription, property.Enum)
-			}
 
 			// Create field model
 			fieldModel := &FieldModel{
@@ -172,6 +169,7 @@ func (b *ModelBuilder) addTypeModels(groupModel *GroupModel, kindModel *KindMode
 				TypeKey:     fieldTypeKey,
 				Description: fieldDescription,
 				Required:    containsString(fieldName, schema.Required),
+				Schema:      property,
 			}
 			typeModel.Fields = append(typeModel.Fields, fieldModel)
 		}

--- a/pkg/builder/model.go
+++ b/pkg/builder/model.go
@@ -3,6 +3,8 @@
 
 package builder
 
+import "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+
 type Model struct {
 	Metadata PageMetadata  `yaml:"metadata"`
 	Groups   []*GroupModel `yaml:"groups"`
@@ -43,6 +45,7 @@ type FieldModel struct {
 	TypeKey     *string
 	Description string
 	Required    bool
+	Schema      apiextensions.JSONSchemaProps
 }
 
 func (m *Model) findGroupModel(group, version string) *GroupModel {

--- a/templates/frontmatter.tmpl
+++ b/templates/frontmatter.tmpl
@@ -70,7 +70,27 @@ Resource Types:
       <tr>
         <td><b>{{if .TypeKey}}<a href="{{.TypeKey}}">{{.Name}}</a>{{else}}{{.Name}}{{end}}</b></td>
         <td>{{.Type}}</td>
-        <td>{{.Description}}</td>
+        <td>
+          {{.Description}}<br/>
+          {{- if or .Schema.Format .Schema.Enum .Schema.Default .Schema.Minimum .Schema.Maximum }}
+          <br/>
+          {{- end}}
+          {{- if .Schema.Format }}
+            <i>Format</i>: {{ .Schema.Format }}<br/>
+          {{- end }}
+          {{- if .Schema.Enum }}
+            <i>Enum</i>: {{ .Schema.Enum | toStrings | join ", " }}<br/>
+          {{- end }}
+          {{- if .Schema.Default }}
+            <i>Default</i>: {{ .Schema.Default }}<br/>
+          {{- end }}
+          {{- if .Schema.Minimum }}
+            <i>Minimum</i>: {{ .Schema.Minimum }}<br/>
+          {{- end }}
+          {{- if .Schema.Maximum }}
+            <i>Maximum</i>: {{ .Schema.Maximum }}<br/>
+          {{- end }}
+        </td>
         <td>{{.Required}}</td>
       </tr>
       {{- end -}}

--- a/templates/markdown.tmpl
+++ b/templates/markdown.tmpl
@@ -64,7 +64,27 @@ Resource Types:
       <tr>
         <td><b>{{if .TypeKey}}<a href="#{{.TypeKey}}">{{.Name}}</a>{{else}}{{.Name}}{{end}}</b></td>
         <td>{{.Type}}</td>
-        <td>{{.Description}}</td>
+        <td>
+          {{.Description}}<br/>
+          {{- if or .Schema.Format .Schema.Enum .Schema.Default .Schema.Minimum .Schema.Maximum }}
+          <br/>
+          {{- end}}
+          {{- if .Schema.Format }}
+            <i>Format</i>: {{ .Schema.Format }}<br/>
+          {{- end }}
+          {{- if .Schema.Enum }}
+            <i>Enum</i>: {{ .Schema.Enum | toStrings | join ", " }}<br/>
+          {{- end }}
+          {{- if .Schema.Default }}
+            <i>Default</i>: {{ .Schema.Default }}<br/>
+          {{- end }}
+          {{- if .Schema.Minimum }}
+            <i>Minimum</i>: {{ .Schema.Minimum }}<br/>
+          {{- end }}
+          {{- if .Schema.Maximum }}
+            <i>Maximum</i>: {{ .Schema.Maximum }}<br/>
+          {{- end }}
+        </td>
         <td>{{.Required}}</td>
       </tr>
       {{- end -}}


### PR DESCRIPTION
Add `Schema` field ([JSONSchemaProps](https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions#JSONSchemaProps)) to  the field model.

Also:
- Removed enum values from description string
- Added  Format, Enum, Default, Minimum and Maximum in the built-in templates.


Closes #54

