### PR TITLE
ci: build and publish multi-arch docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.19
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker Login
         uses: docker/login-action@v3
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -13,9 +14,12 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
       {{ .ProjectName }}_
@@ -27,11 +31,49 @@ archives:
     # use zip for windows archives
     format_overrides:
     - goos: windows
-      format: zip
+      formats: [zip]
+dockers:
+  - id: amd64
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/fybrik/crdoc:{{ .Version }}-amd64"
+      - "ghcr.io/fybrik/crdoc:latest-amd64"
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.source=https://github.com/fybrik/crdoc"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+  - id: arm64
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/fybrik/crdoc:{{ .Version }}-arm64"
+      - "ghcr.io/fybrik/crdoc:latest-arm64"
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.source=https://github.com/fybrik/crdoc"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+
+docker_manifests:
+  - name_template: "ghcr.io/fybrik/crdoc:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/fybrik/crdoc:{{ .Version }}-amd64"
+      - "ghcr.io/fybrik/crdoc:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/fybrik/crdoc:latest"
+    image_templates:
+      - "ghcr.io/fybrik/crdoc:latest-amd64"
+      - "ghcr.io/fybrik/crdoc:latest-arm64"
+
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Builds and pushes multi-arch (amd64/arm64) container images to ghcr.io/fybrik/crdoc via GoReleaser, with a combined manifest and latest tags. Adds QEMU + Buildx setup to the release workflow for cross-platform builds, arm64 to the build matrix, and migrates the GoReleaser config to the v2 schema.

Fixes https://github.com/fybrik/crdoc/issues/322